### PR TITLE
docs: update benchmark results with latest performance metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ tiny-rag has been evaluated on standard Japanese retrieval benchmarks to demonst
 
 | Dataset | NDCG@10 | MRR@10 | MAP@10 | Hits@10 | Avg Query Time |
 |---------|---------|---------|---------|---------|----------------|
-| JQaRA   | 0.7944  | 0.8000  | -       | -       | 0.755 sec      |
-| JaCWIR  | -       | -       | 0.8000  | 0.8000  | 1.185 sec      |
+| JQaRA   | 0.8553  | 0.8796  | -       | -       | 0.771 sec      |
+| JaCWIR  | -       | -       | 0.8368  | 0.8646  | 0.925 sec      |
 
 ### Running Benchmarks
 
@@ -113,8 +113,8 @@ python -m bench.benchmark --dimensions 512 --max-queries 10
 
 ### Performance Insights
 
-- **High Accuracy**: Achieves 0.79-0.80 scores across all metrics
-- **Practical Speed**: Query processing under 1.2 seconds even for large datasets
+- **High Accuracy**: Achieves 0.84-0.88 scores across all metrics
+- **Practical Speed**: Query processing under 1 second even for large datasets
 - **Scalable**: Performance scales reasonably with dataset size
 - **CPU-Friendly**: All processing runs efficiently on standard hardware
 


### PR DESCRIPTION
## Summary

This PR updates the benchmark results in README.md with the latest performance metrics from the full benchmark evaluation.

## Changes

- Updated JQaRA benchmark results:
  - NDCG@10: 0.7944 → 0.8553 (+7.7% improvement)
  - MRR@10: 0.8000 → 0.8796 (+10.0% improvement)
  - Query time: 0.755 → 0.771 sec

- Updated JaCWIR benchmark results:
  - MAP@10: 0.8000 → 0.8368 (+4.6% improvement)
  - Hits@10: 0.8000 → 0.8646 (+8.1% improvement)
  - Query time: 1.185 → 0.925 sec (22% faster)

- Updated performance insights to reflect the new accuracy range (0.84-0.88)

## Test Plan

- [x] Benchmark results match the actual output from `make bench-full`
- [x] All metrics are correctly formatted in the table
- [x] Performance insights accurately reflect the new results

🤖 Generated with [Claude Code](https://claude.ai/code)